### PR TITLE
Add optional starting cursor

### DIFF
--- a/go_http/contacts.py
+++ b/go_http/contacts.py
@@ -51,16 +51,20 @@ class ContactsApiClient(object):
         r.raise_for_status()
         return r.json()
 
-    def contacts(self):
+    def contacts(self, start_cursor=""):
         """
         Retrieve all contacts.
 
         This uses the API's paginated contact download.
 
+        :param start_cursor:
+            An optional parameter that declares the cursor to start fetching
+            the contacts from.
+
         :returns:
             An iterator over all contacts.
         """
-        page = self._api_request("GET", "contacts", "")
+        page = self._api_request("GET", "contacts", start_cursor)
         while True:
             for contact in page['data']:
                 yield contact

--- a/go_http/contacts.py
+++ b/go_http/contacts.py
@@ -51,7 +51,7 @@ class ContactsApiClient(object):
         r.raise_for_status()
         return r.json()
 
-    def contacts(self, start_cursor=""):
+    def contacts(self, start_cursor=None):
         """
         Retrieve all contacts.
 
@@ -64,7 +64,11 @@ class ContactsApiClient(object):
         :returns:
             An iterator over all contacts.
         """
-        page = self._api_request("GET", "contacts", start_cursor)
+        if start_cursor:
+            page = self._api_request(
+                "GET", "contacts", "?cursor=%s" % start_cursor)
+        else:
+            page = self._api_request("GET", "contacts", "")
         while True:
             for contact in page['data']:
                 yield contact

--- a/go_http/tests/test_contacts.py
+++ b/go_http/tests/test_contacts.py
@@ -156,6 +156,28 @@ class TestContactsApiClient(TestCase):
         self.assertEqual(
             sort_by_msidn(contacts), sort_by_msidn(expected_contacts))
 
+    def test_contacts_multiple_pages_with_cursor(self):
+        expected_contacts = []
+        for i in range(self.MAX_CONTACTS_PER_PAGE):
+            expected_contacts.append(self.make_existing_contact({
+                u"msisdn": u"+155564%d" % (i,),
+                u"name": u"Arthur",
+                u"surname": u"of Camelot",
+            }))
+        expected_contacts.append(self.make_existing_contact({
+            u"msisdn": u"+15556",
+            u"name": u"Arthur",
+            u"surname": u"of Camelot",
+        }))
+        contacts_api = self.make_client()
+        first_page = contacts_api._api_request("GET", "contacts", "")
+        cursor = first_page['cursor']
+        contacts = list(contacts_api.contacts(start_cursor=cursor))
+        contacts.extend(first_page['data'])
+        sort_by_msidn = lambda l: sorted(l, key=lambda d: d['msisdn'])
+        self.assertEqual(
+            sort_by_msidn(contacts), sort_by_msidn(expected_contacts))
+
     def test_create_contact(self):
         contacts = self.make_client()
         contact_data = {


### PR DESCRIPTION
Add an optional parameter to the `contacts` function to allow specifying the starting cursor.