### PR TITLE
handle opted out contacts

### DIFF
--- a/go_http/exceptions.py
+++ b/go_http/exceptions.py
@@ -1,0 +1,13 @@
+class UserOptedOutException(Exception):
+    """
+    Exception raised if a message is sent to a recipient who has opted out.
+
+    Attributes:
+        to_addr - The address of the opted out recipient
+        message - The message content
+        reason  - The error reason given by the API
+    """
+    def __init__(self, to_addr, message, reason):
+        self.to_addr = to_addr
+        self.message = message
+        self.reason = reason

--- a/go_http/send.py
+++ b/go_http/send.py
@@ -6,6 +6,9 @@ import logging
 import uuid
 
 import requests
+from requests.exceptions import HTTPError
+
+from go_http.exceptions import UserOptedOutException
 
 
 class HttpApiSender(object):
@@ -66,7 +69,17 @@ class HttpApiSender(object):
             "content": content,
             "to_addr": to_addr,
         }
-        return self._api_request('messages.json', data)
+        try:
+            return self._api_request('messages.json', data)
+        except HTTPError as e:
+            response = e.response.json()
+            if (
+                    e.response.status_code != 400 or
+                    'opted out' not in response.get('reason') or
+                    response.get('success')):
+                raise e
+            raise UserOptedOutException(
+                to_addr, content, response.get('reason'))
 
     def fire_metric(self, metric, value, agg="last"):
         """ Fire a value for a metric.

--- a/go_http/send.py
+++ b/go_http/send.py
@@ -75,7 +75,7 @@ class HttpApiSender(object):
             response = e.response.json()
             if (
                     e.response.status_code != 400 or
-                    'opted out' not in response.get('reason') or
+                    'opted out' not in response.get('reason', '') or
                     response.get('success')):
                 raise e
             raise UserOptedOutException(

--- a/go_http/tests/test_send.py
+++ b/go_http/tests/test_send.py
@@ -78,13 +78,13 @@ class TestHttpApiSender(TestCase):
                     "reason": "Recipient with msisdn to-addr-1 has opted out"}
                     ),
                 status=400))
-        with self.assertRaises(UserOptedOutException) as e:
+        try:
             self.sender.send_text('to-addr-1', "foo")
-        exception = e.exception
-        self.assertEqual(exception.to_addr, 'to-addr-1')
-        self.assertEqual(exception.message, 'foo')
-        self.assertEqual(
-            exception.reason, 'Recipient with msisdn to-addr-1 has opted out')
+        except UserOptedOutException as e:
+            self.assertEqual(e.to_addr, 'to-addr-1')
+            self.assertEqual(e.message, 'foo')
+            self.assertEqual(
+                e.reason, 'Recipient with msisdn to-addr-1 has opted out')
 
     def test_fire_metric(self):
         adapter = RecordingAdapter(

--- a/go_http/tests/test_send.py
+++ b/go_http/tests/test_send.py
@@ -9,6 +9,8 @@ from requests_testadapter import TestAdapter, TestSession
 from go_http.send import HttpApiSender, LoggingSender
 from go_http.exceptions import UserOptedOutException
 
+from requests.exceptions import HTTPError
+
 
 class RecordingAdapter(TestAdapter):
     """ Record the request that was handled by the adapter.
@@ -85,6 +87,27 @@ class TestHttpApiSender(TestCase):
             self.assertEqual(e.message, 'foo')
             self.assertEqual(
                 e.reason, 'Recipient with msisdn to-addr-1 has opted out')
+
+    def test_send_to_other_http_error(self):
+        """
+        HTTP errors should not be raised as UserOptedOutExceptions if they are
+        not user opted out errors.
+        """
+        self.session.mount(
+            "http://example.com/api/v1/go/http_api_nostream/conv-key/"
+            "messages.json", TestAdapter(
+                json.dumps({
+                    "success": False,
+                    "reason": "No unicorns were found"
+                    }),
+                status=400))
+        try:
+            self.sender.send_text('to-addr-1', 'foo')
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 400)
+            response = e.response.json()
+            self.assertFalse(response['success'])
+            self.assertEqual(response['reason'], "No unicorns were found")
 
     def test_fire_metric(self):
         adapter = RecordingAdapter(


### PR DESCRIPTION
If a contact is opted out, the new API will send a 400 error; we should catch this error and raise a ContactOptedOut error instead.