### PR TITLE
Raise a custom exception that allows easily restarting paginated contact requests.

### DIFF
--- a/go_http/contacts.py
+++ b/go_http/contacts.py
@@ -10,6 +10,8 @@ import json
 
 import requests
 
+from go_http.exceptions import PagedException
+
 
 class ContactsApiClient(object):
 
@@ -77,8 +79,11 @@ class ContactsApiClient(object):
                 yield contact
             if page['cursor'] is None:
                 break
-            page = self._api_request(
-                "GET", "contacts", "?cursor=%s" % page['cursor'])
+            try:
+                page = self._api_request(
+                    "GET", "contacts", "?cursor=%s" % page['cursor'])
+            except Exception as err:
+                raise PagedException(page['cursor'], err)
 
     def create_contact(self, contact_data):
         """
@@ -211,6 +216,9 @@ class ContactsApiClient(object):
                 yield contact
             if page['cursor'] is None:
                 break
-            page = self._api_request(
-                "GET", "groups/%s" % group_key, "contacts?cursor=%s" %
-                page['cursor'])
+            try:
+                page = self._api_request(
+                    "GET", "groups/%s" % group_key, "contacts?cursor=%s" %
+                    page['cursor'])
+            except Exception as err:
+                raise PagedException(page['cursor'], err)

--- a/go_http/exceptions.py
+++ b/go_http/exceptions.py
@@ -1,3 +1,6 @@
+""" Exceptions raised by API calls. """
+
+
 class UserOptedOutException(Exception):
     """
     Exception raised if a message is sent to a recipient who has opted out.
@@ -11,3 +14,24 @@ class UserOptedOutException(Exception):
         self.to_addr = to_addr
         self.message = message
         self.reason = reason
+
+
+class PagedException(Exception):
+    """
+    Exception raised during paged API calls that can be restarted by
+    specifying a start cursor.
+
+    Attributes:
+        cursor - The value of the cursor for which the paged request failed.
+        error - The exception that occurred.
+    """
+    def __init__(self, cursor, error):
+        self.cursor = cursor
+        self.error = error
+
+    def __repr__(self):
+        return "<PagedException cursor=%r error=%r>" % (
+            self.cursor, self.error)
+
+    def __str__(self):
+        return repr(self)

--- a/go_http/tests/test_exceptions.py
+++ b/go_http/tests/test_exceptions.py
@@ -1,0 +1,28 @@
+"""
+Tests for go_http.exceptions.
+"""
+
+from unittest import TestCase
+
+from go_http.exceptions import PagedException
+
+
+class TestPagedException(TestCase):
+    def test_creation(self):
+        err = ValueError("Testing Error")
+        p = PagedException(u"12345", err)
+        self.assertTrue(isinstance(p, Exception))
+        self.assertEqual(p.cursor, u"12345")
+        self.assertEqual(p.error, err)
+
+    def test_repr(self):
+        p = PagedException(u"abcde", ValueError("Test ABC"))
+        self.assertEqual(
+            repr(p),
+            "<PagedException cursor=u'abcde' error=ValueError('Test ABC',)>")
+
+    def test_str(self):
+        p = PagedException(u"lmnop", ValueError("Test LMN"))
+        self.assertEqual(
+            str(p),
+            "<PagedException cursor=u'lmnop' error=ValueError('Test LMN',)>")


### PR DESCRIPTION
Currently if an iteration through `contacts()` or `group_contacts("mygroup")` fails, there is no easy way to restart it because the cursor is thrown away. We should raise a custom exception that contains the cursor so that it can be restarted if needed.