### PR TITLE
Add support for firing metrics via the new metrics posting route on the metrics API.

### DIFF
--- a/go_http/metrics.py
+++ b/go_http/metrics.py
@@ -75,7 +75,7 @@ class MetricsApiClient(object):
         }
         return self._api_request("GET", "metrics/", payload)
 
-    def fire(self, **metrics):
+    def fire(self, metrics):
         """
         Fire metrics.
 

--- a/go_http/metrics.py
+++ b/go_http/metrics.py
@@ -74,3 +74,36 @@ class MetricsApiClient(object):
             "nulls": nulls
         }
         return self._api_request("GET", "metrics/", payload)
+
+    def fire(self, **metrics):
+        """
+        Fire metrics.
+
+        :param dict metrics:
+            A mapping of metric names to floating point metric values.
+
+        When metrics are fired they may specify an aggregator. The
+        aggregation method is determined by the suffix of the metric name.
+        For example, ``foo.last`` fires a metric that uses the ``last``
+        aggregation method.
+
+        The available aggregators are:
+
+        :Average:
+            ``avg``. Aggregates by averaging the values in each time period.
+        :Sum:
+            ``sum``. Aggregates by summing all the values in each time period.
+        :Maximum:
+            ``max``. Aggregates by choosing the maximum value in each time
+            period.
+        :Minimum:
+            ``min``. Aggregates by choosing the minimum value in each time
+            period.
+        :Last:
+            ``last``. Aggregates by choosing the last value in each time
+            period.
+
+        Note that metrics can also be fired via an HTTP conversation API.
+        See :meth:`go_http.send.HttpApiSender.fire_metric`.
+        """
+        return self._api_request("POST", "metrics/", metrics)

--- a/go_http/metrics.py
+++ b/go_http/metrics.py
@@ -82,7 +82,7 @@ class MetricsApiClient(object):
         :param dict metrics:
             A mapping of metric names to floating point metric values.
 
-        When metrics are fired they may specify an aggregator. The
+        When metrics are fired they must specify an aggregator. The
         aggregation method is determined by the suffix of the metric name.
         For example, ``foo.last`` fires a metric that uses the ``last``
         aggregation method.

--- a/go_http/metrics.py
+++ b/go_http/metrics.py
@@ -87,6 +87,9 @@ class MetricsApiClient(object):
         For example, ``foo.last`` fires a metric that uses the ``last``
         aggregation method.
 
+        If a metric name does not end in a valid aggregator name, firing
+        the set of metrics will fail.
+
         The available aggregators are:
 
         :Average:

--- a/go_http/send.py
+++ b/go_http/send.py
@@ -147,6 +147,9 @@ class HttpApiSender(object):
         :param str agg:
             Aggregation type. Defaults to ``'last'``. Other allowed values are
             ``'sum'``, ``'avg'``, ``'max'`` and ``'min'``.
+
+        Note that metrics can also be fired via the metrics API.
+        See :meth:`go_http.metrics.MetricsApiClient.fire`.
         """
         data = [
             [

--- a/go_http/tests/test_metrics.py
+++ b/go_http/tests/test_metrics.py
@@ -89,7 +89,7 @@ class TestMetricApiClient(TestCase):
             "http://example.com/api/v1/go/"
             "metrics/", adapter)
 
-        result = self.client.fire(**{
+        result = self.client.fire({
             "foo.last": 3.1415,
         })
         self.assertEqual(result, response)


### PR DESCRIPTION
The Vumi Go metrics API gained support for firing metrics in https://github.com/praekelt/go-metrics-api/pull/16. We need to add support for calling that to the metrics client.