### PR TITLE
Don't try and decode HTTP errors

### DIFF
--- a/go_http/send.py
+++ b/go_http/send.py
@@ -64,16 +64,15 @@ class HttpApiSender(object):
         except HTTPError as e:
             try:
                 response = e.response.json()
-                if (
-                        e.response.status_code != 400 or
-                        'opted out' not in response.get('reason', '') or
-                        response.get('success')):
-                    raise e
-                raise UserOptedOutException(
-                    data.get("to_addr"), data.get("content"),
-                    response.get('reason'))
-            except ValueError:
+            except ValueError:  # Some HTTP responses are not decodable
                 raise e
+            if (e.response.status_code != 400 or
+                    'opted out' not in response.get('reason', '') or
+                    response.get('success')):
+                raise e
+            raise UserOptedOutException(
+                data.get("to_addr"), data.get("content"),
+                response.get('reason'))
 
     def send_text(self, to_addr, content, session_event=None):
         """ Send a text message to an address.

--- a/go_http/tests/test_metrics.py
+++ b/go_http/tests/test_metrics.py
@@ -68,9 +68,8 @@ class TestMetricApiClient(TestCase):
         adapter = RecordingAdapter(json.dumps(response))
         self.session.mount(
             "http://example.com/api/v1/go/"
-            "metrics/?from=-30d&interval=1d"
-            "&m=stores.store_name.metric_name.agg"
-            "&nulls=omit", adapter)
+            "metrics/?m=stores.store_name.metric_name.agg"
+            "&interval=1d&from=-30d&nulls=omit", adapter)
 
         result = self.client.get_metric(
             "stores.store_name.metric_name.agg", "-30d", "1d", "omit")

--- a/go_http/tests/test_send.py
+++ b/go_http/tests/test_send.py
@@ -13,6 +13,7 @@ from requests.exceptions import HTTPError
 
 
 class RecordingAdapter(TestAdapter):
+
     """ Record the request that was handled by the adapter.
     """
     request = None
@@ -23,6 +24,7 @@ class RecordingAdapter(TestAdapter):
 
 
 class TestHttpApiSender(TestCase):
+
     def setUp(self):
         self.session = TestSession()
         self.sender = HttpApiSender(
@@ -92,7 +94,7 @@ class TestHttpApiSender(TestCase):
                 json.dumps({
                     "success": False,
                     "reason": "Recipient with msisdn to-addr-1 has opted out"}
-                    ),
+                ),
                 status=400))
         try:
             self.sender.send_text('to-addr-1', "foo")
@@ -113,7 +115,7 @@ class TestHttpApiSender(TestCase):
                 json.dumps({
                     "success": False,
                     "reason": "No unicorns were found"
-                    }),
+                }),
                 status=400))
         try:
             self.sender.send_text('to-addr-1', 'foo')
@@ -122,6 +124,23 @@ class TestHttpApiSender(TestCase):
             response = e.response.json()
             self.assertFalse(response['success'])
             self.assertEqual(response['reason'], "No unicorns were found")
+
+    def test_send_text_to_other_http_error_not_json(self):
+        """
+        HTTP errors that are not json encode should be raised without decoding
+        errors
+        """
+        self.session.mount(
+            "http://example.com/api/v1/go/http_api_nostream/conv-key/"
+            "messages.json", TestAdapter(
+                "401 Client Error: Unauthorized",
+                status=401))
+        try:
+            self.sender.send_text('to-addr-1', 'foo')
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 401)
+            self.assertEqual(e.response.text,
+                             "401 Client Error: Unauthorized")
 
     def test_send_voice(self):
         self.check_successful_send(
@@ -198,6 +217,7 @@ class TestHttpApiSender(TestCase):
 
 
 class RecordingHandler(logging.Handler):
+
     """ Record logs. """
     logs = None
 
@@ -208,6 +228,7 @@ class RecordingHandler(logging.Handler):
 
 
 class TestLoggingSender(TestCase):
+
     def setUp(self):
         self.sender = LoggingSender('go_http.test')
         self.handler = RecordingHandler()

--- a/go_http/tests/test_send.py
+++ b/go_http/tests/test_send.py
@@ -13,7 +13,6 @@ from requests.exceptions import HTTPError
 
 
 class RecordingAdapter(TestAdapter):
-
     """ Record the request that was handled by the adapter.
     """
     request = None
@@ -217,7 +216,6 @@ class TestHttpApiSender(TestCase):
 
 
 class RecordingHandler(logging.Handler):
-
     """ Record logs. """
     logs = None
 


### PR DESCRIPTION
Generally HTTP error messages aren't JSON decodeable, so this: https://github.com/praekelt/go-http-api/blob/develop/go_http/send.py#L75

throws `ValueError("No JSON object could be decoded")`