### PR TITLE
Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.5"
 install:
   - "pip install -r requirements.txt --use-wheel"
   - "pip install -r requirements-dev.txt --use-wheel"


### PR DESCRIPTION
Currently an issue arises from `requests_testadapter`:
```
BytesIO.__init__(self, stream)
TypeError: 'str' does not support the buffer interface
```
We have worked around this in seed-stage-based-messaging tests by encoding it:
```
adapter = RecordingAdapter(json.dumps(response).encode('utf-8'))
```

This would also require an updated importing of url_parse:
```
try:
    from urllib.parse import urlparse
except ImportError:
    from urlparse import urlparse
```