### PR TITLE
Add support for the JSON-RPC Go API.

### DIFF
--- a/go_http/__init__.py
+++ b/go_http/__init__.py
@@ -1,9 +1,11 @@
 """Vumi Go HTTP API client library."""
 
 from .send import HttpApiSender, LoggingSender
+from .account import AccountApiClient
 
 __version__ = "0.3.1a0"
 
 __all__ = [
     'HttpApiSender', 'LoggingSender',
+    'AccountApiClient',
 ]

--- a/go_http/account.py
+++ b/go_http/account.py
@@ -1,0 +1,128 @@
+"""
+Client for Vumi Go's JSON-RPC based account, conversations, channel and
+routing API.
+"""
+
+import json
+
+import requests
+
+from go_http.exceptions import JsonRpcException
+
+
+class AccountApiClient(object):
+    """
+    Client for Vumi Go's JSON-RPC based account, conversations, channel and
+    routing API.
+
+    :param str auth_token:
+        An OAuth 2 access token. NOTE: This will be replaced by a proper
+        authentication system at some point.
+
+    :param str api_url:
+        The full URL of the HTTP API. Defaults to
+        ``https://go.vumi.org/api/v1/go``.
+
+    :type session:
+        :class:`requests.Session`
+    :param session:
+        Requests session to use for HTTP requests. Defaults to a new session.
+    """
+
+    def __init__(self, auth_token, api_url=None, session=None):
+        self.auth_token = auth_token
+        if api_url is None:
+            api_url = "https://go.vumi.org/api/v1/go"
+        self.api_url = api_url.rstrip('/')
+        if session is None:
+            session = requests.Session()
+        self.session = session
+
+    def _api_request(self, method, params):
+        url = "%s/api/" % (self.api_url,)
+        headers = {
+            "Content-Type": "application/json; charset=utf-8",
+            "Authorization": "Bearer %s" % (self.auth_token,),
+        }
+        data = {
+            "method": method,
+            "params": params,
+            "jsonrpc": "2.0",
+            "id": 0,
+        }
+        r = self.session.post(url, data=json.dumps(data), headers=headers)
+        r.raise_for_status()
+        rpc_response = r.json()
+        rpc_error = rpc_response['error']
+        if rpc_error is not None:
+            raise JsonRpcException(
+                fault=rpc_error['fault'], fault_code=rpc_error['faultCode'],
+                fault_string=rpc_error['fault_string'])
+        return rpc_response['result']
+
+    def campaigns(self):
+        """
+        Return a list of campaigns accessible by the account.
+
+        Note: The server-side implementation of this API method is a stub. It
+        always returns a single campaign whose name is 'Your Campaign' and
+        whose key is the account key.
+        """
+        return self._api_request("campaigns", [])
+
+    def conversations(self, campaign_id):
+        """
+        Return a list of conversations for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        """
+        return self._api_request("conversations", [campaign_id])
+
+    def channels(self, campaign_id):
+        """
+        Return a list of channels for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        """
+        return self._api_request("conversations", [campaign_id])
+
+    def routers(self, campaign_id):
+        """
+        Return a list of routers for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        """
+        return self._api_request("routers", [campaign_id])
+
+    def routing_entries(self, campaign_id):
+        """
+        Return a list of routing entries for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        """
+        return self._api_request("routing_entries", [campaign_id])
+
+    def routing_table(self, campaign_id):
+        """
+        Return the complete routing table for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        """
+        return self._api_request("routing_table", [campaign_id])
+
+    def update_routing_table(self, campaign_id, routing_table):
+        """
+        Update the routing table for the campaign.
+
+        :param str campaign_id:
+            The campaign or account id.
+        :param dict routing_table:
+            The complete new routing table.
+        """
+        return self._api_request(
+            "update_routing_table", [campaign_id, routing_table])

--- a/go_http/account.py
+++ b/go_http/account.py
@@ -86,7 +86,7 @@ class AccountApiClient(object):
         :param str campaign_id:
             The campaign or account id.
         """
-        return self._api_request("conversations", [campaign_id])
+        return self._api_request("channels", [campaign_id])
 
     def routers(self, campaign_id):
         """

--- a/go_http/account.py
+++ b/go_http/account.py
@@ -57,7 +57,7 @@ class AccountApiClient(object):
         if rpc_error is not None:
             raise JsonRpcException(
                 fault=rpc_error['fault'], fault_code=rpc_error['faultCode'],
-                fault_string=rpc_error['fault_string'])
+                fault_string=rpc_error['faultString'])
         return rpc_response['result']
 
     def campaigns(self):

--- a/go_http/exceptions.py
+++ b/go_http/exceptions.py
@@ -35,3 +35,18 @@ class PagedException(Exception):
 
     def __str__(self):
         return repr(self)
+
+
+class JsonRpcException(Exception):
+    """
+    Exception raised if a JSON-RPC error is returned.
+
+    Attributes:
+        fault - The type of fault (e.g. 'Fault').
+        fault_code - The error code (e.g. 8002).
+        fault_string - A string describing the error.
+    """
+    def __init__(self, fault, fault_code, fault_string):
+        self.fault = fault
+        self.fault_code = fault_code
+        self.fault_string = fault_string

--- a/go_http/tests/fixtures/account.py
+++ b/go_http/tests/fixtures/account.py
@@ -1,0 +1,69 @@
+"""Fixtures for the account API."""
+
+import copy
+
+campaigns = [{
+    u'name': u'Your Campaign',
+    u'key': u'key-hash-1',
+}]
+
+channels = [{
+    u'endpoints': [{
+        u'uuid': u'TRANSPORT_TAG:tagpool:tagname::default',
+        u'name': u'default',
+    }],
+    u'tag': [u'tagpool', u'tagname'],
+    u'description': u'Tagpool: Tagname',
+    u'name': u'A nice name',
+    u'uuid': u'channel-uuid-1',
+}]
+
+conversations = [{
+    u'type': u'dialogue',
+    u'status': u'running',
+    u'uuid': u'conv-1',
+    u'name': u'Test Dialogue',
+    u'endpoints': [{
+        u'uuid': u'CONVERSATION:dialogue:conv-1::default',
+        u'name': u'default',
+    }],
+    u'description': u'Small dialogue for testing'
+}]
+
+routers = [{
+    u'status': u'running',
+    u'description': u'Keyword router for my app',
+    u'conversation_endpoints': [{
+        u'uuid': u'ROUTER:keyword:rtr-1:OUTBOUND::default',
+        u'name': u'default',
+    }, {
+        u'uuid': u'ROUTER:keyword:rtr-1:OUTBOUND::keyword_two',
+        u'name': u'keyword_two',
+    }, {
+        u'uuid': u'ROUTER:keyword:rtr-1:OUTBOUND::keyword_one',
+        u'name': u'keyword_one',
+    }],
+    u'uuid': u'rtr-1',
+    u'channel_endpoints': [{
+        u'uuid': u'ROUTER:keyword:rtr-1:INBOUND::default',
+        u'name': u'default',
+    }],
+    u'type': u'keyword',
+    u'name': u'Keywords for my app',
+}]
+
+routing_entries = [{
+    u'source': {
+        u'uuid': u'TRANSPORT_TAG:tagpool:tagname::default',
+    },
+    u'target': {
+        u'uuid': u'CONVERSATION:conv_type:conv-id-1::default',
+    },
+}]
+
+routing_table = copy.deepcopy({
+    u'channels': channels,
+    u'conversations': conversations,
+    u'routers': routers,
+    u'routing_entries': routing_entries,
+})

--- a/go_http/tests/test_account.py
+++ b/go_http/tests/test_account.py
@@ -1,0 +1,148 @@
+"""
+Tests for go_http.account
+"""
+
+import json
+from unittest import TestCase
+
+from requests import HTTPError
+from requests.adapters import HTTPAdapter
+from requests_testadapter import TestSession, Resp, TestAdapter
+
+from go_http.account import AccountApiClient
+from go_http.exceptions import JsonRpcException
+
+
+class FakeAccountApiAdapter(HTTPAdapter):
+    """
+    Adapter providing a fake account API.
+
+    This inherits directly from HTTPAdapter instead of using TestAdapter
+    because it overrides everything TestAdaptor does.
+    """
+
+    def __init__(self, account_api):
+        self.account_api = account_api
+        super(FakeAccountApiAdapter, self).__init__()
+
+    def send(self, request, stream=False, timeout=None,
+             verify=True, cert=None, proxies=None):
+        response = self.account_api.handle_request(request)
+        r = self.build_response(request, response)
+        if not stream:
+            # force prefetching content unless streaming in use
+            r.content
+        return r
+
+
+class FakeAccountApi(object):
+    def __init__(self, api_path, auth_token):
+        self.api_path = api_path
+        self.auth_token = auth_token
+
+    def http_error_response(self, http_code, error):
+        return Resp("403 Forbidden", 403, headers={})
+
+    def jsonrpc_error_response(self, fault, fault_code, fault_string):
+        return Resp(json.dumps({
+            "error": {
+                "fault": fault, "faultCode": fault_code,
+                "faultString": fault_string,
+            },
+        }), 200, headers={})
+
+    def jsonrpc_success_response(self, result):
+        return Resp(json.dumps({
+            "error": None,
+            "result": result,
+        }), 200, headers={})
+
+    def handle_request(self, request):
+        if request.headers['Authorization'] != 'Bearer %s' % (
+                self.auth_token):
+            return self.http_error_response(403, "403 Forbidden")
+        if request.headers['Content-Type'] != (
+                'application/json; charset=utf-8'):
+            return self.http_error_response(400, "Invalid Content-Type.")
+        if request.method != "POST":
+            return self.jsonrpc_error_response(
+                "Fault", 8000, "Only POST method supported")
+        # TODO: handle requests properly
+        return self.jsonrpc_success_response({})
+
+
+class TestAccountApiClient(TestCase):
+    API_URL = "http://example.com/go"
+    AUTH_TOKEN = "auth_token"
+
+    def setUp(self):
+        self.account_backend = FakeAccountApi("go/", self.AUTH_TOKEN)
+        self.session = TestSession()
+        self.adapter = FakeAccountApiAdapter(self.account_backend)
+        self.simulate_api_up()
+
+    def simulate_api_down(self):
+        self.session.mount(self.API_URL, TestAdapter("API is down", 500))
+
+    def simulate_api_up(self):
+        self.session.mount(self.API_URL, self.adapter)
+
+    def make_client(self, auth_token=AUTH_TOKEN):
+        return AccountApiClient(
+            auth_token, api_url=self.API_URL, session=self.session)
+
+    def assert_http_error(self, expected_status, func, *args, **kw):
+        try:
+            func(*args, **kw)
+        except HTTPError as err:
+            self.assertEqual(err.response.status_code, expected_status)
+        else:
+            self.fail(
+                "Expected HTTPError with status %s." % (expected_status,))
+
+    def assert_jsonrpc_exception(self, f, *args, **kw):
+        try:
+            f(*args, **kw)
+        except Exception as err:
+            self.assertTrue(isinstance(err, JsonRpcException))
+            self.assertTrue(isinstance(err.cursor, unicode))
+            self.assertTrue(isinstance(err.error, Exception))
+        return err
+
+    def test_assert_http_error(self):
+        self.session.mount("http://bad.example.com/", TestAdapter("", 500))
+
+        def bad_req():
+            r = self.session.get("http://bad.example.com/")
+            r.raise_for_status()
+
+        # Fails when no exception is raised.
+        self.assertRaises(
+            self.failureException, self.assert_http_error, 404, lambda: None)
+
+        # Fails when an HTTPError with the wrong status code is raised.
+        self.assertRaises(
+            self.failureException, self.assert_http_error, 404, bad_req)
+
+        # Passes when an HTTPError with the expected status code is raised.
+        self.assert_http_error(500, bad_req)
+
+        # Non-HTTPError exceptions aren't caught.
+        def raise_error():
+            raise ValueError()
+
+        self.assertRaises(ValueError, self.assert_http_error, 404, raise_error)
+
+    def test_default_session(self):
+        import requests
+        client = AccountApiClient(self.AUTH_TOKEN)
+        self.assertTrue(isinstance(client.session, requests.Session))
+
+    def test_default_api_url(self):
+        client = AccountApiClient(self.AUTH_TOKEN)
+        self.assertEqual(
+            client.api_url, "https://go.vumi.org/api/v1/go")
+
+    def test_auth_failure(self):
+        client = self.make_client(auth_token="bogus_token")
+        self.assert_http_error(403, client.campaigns)

--- a/go_http/tests/test_account.py
+++ b/go_http/tests/test_account.py
@@ -7,7 +7,7 @@ import copy
 import json
 from unittest import TestCase
 
-from requests import HTTPError
+from requests import HTTPError, Session
 from requests.adapters import HTTPAdapter
 from requests_testadapter import TestSession, Resp, TestAdapter
 
@@ -148,9 +148,8 @@ class TestAccountApiClient(TestCase):
         self.assertRaises(ValueError, self.assert_http_error, 404, raise_error)
 
     def test_default_session(self):
-        import requests
         client = AccountApiClient(self.AUTH_TOKEN)
-        self.assertTrue(isinstance(client.session, requests.Session))
+        self.assertTrue(isinstance(client.session, Session))
 
     def test_default_api_url(self):
         client = AccountApiClient(self.AUTH_TOKEN)

--- a/go_http/tests/test_account.py
+++ b/go_http/tests/test_account.py
@@ -201,3 +201,12 @@ class TestAccountApiClient(TestCase):
         self.assertEqual(
             client.routing_table("campaign-1"),
             fixtures.routing_table)
+
+    def test_update_routing_tabel(self):
+        client = self.make_client()
+        self.account_backend.add_success_response(
+            "update_routing_table", ["campaign-1", fixtures.routing_table],
+            None)
+        self.assertEqual(
+            client.update_routing_table("campaign-1", fixtures.routing_table),
+            None)


### PR DESCRIPTION
The JSON-RPC Go API is now accessible using API keys. It can be accessed using `request` as follows:
```
url = 'https://go.vumi.org/api/v1/go/api/'

headers = {
    "Authorization": "Bearer %s" % API_KEY,
}

payload = {
    "method": "conversations",
    "params": [ACCOUNT_ID],
    "jsonrpc": "2.0",
    "id": 0,   
}

response = requests.post(url, data=json.dumps(payload), headers=headers).json()
```
Methods that need to be supported are:
* `campaigns()`
* `conversations(campaign_key)`
* `channels(campaign_key)`
* `routers(campaign_key)`
* `routing_entries(campaign_key)`
* `routing_table(campaign_key)`
* `update_routing_table(campaign_key, routing)`